### PR TITLE
Cannot find module 'autoprefixer'

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/givebest/webpack-multiple-entry#readme",
   "devDependencies": {
     "art-template-loader": "^1.4.3",
+    "autoprefixer": "^7.1.2",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",
     "babel-preset-env": "^1.5.2",


### PR DESCRIPTION
错误发生在npm run dev